### PR TITLE
Add RainbowUnicorn backed ColorType for Active Record

### DIFF
--- a/lib/rainbow_unicorn/active_record.rb
+++ b/lib/rainbow_unicorn/active_record.rb
@@ -1,0 +1,17 @@
+class RainbowUnicorn::ColorType < ActiveRecord::Type::Value
+  def cast_value(value)
+    case value
+    when RainbowUnicorn::Color then value
+    when String  then RainbowUnicorn::Color.from_hex(value)
+    when Numeric then RainbowUnicorn::Color.from_i(value)
+    else
+      super
+    end
+  end
+
+  def serialize(value)
+    value.to_i
+  end
+
+  ActiveRecord::Type.register :rainbow_unicorn_color, self
+end


### PR DESCRIPTION
@joeldrapper I was curious to see what an Active Record type would look like based on your Mastodon posts. It turned out to be a little more involved than I'd thought it would be, so I figured I'd open a PR with it.

I'm not sure if this is something you'd want to ship with? If so, it could be nice to add the type to README.md for copy-pasting into apps.

Anyway, this makes it so users could do `require "rainbow_unicorn/active_record"` in their apps and get access to:

```ruby
class Theme < ApplicationRecord
  attribute :color, :rainbow_unicorn_color # This thing!
end
```

They could use it like so:

```ruby
require "test_helper"

class ThemeTest < ActiveSupport::TestCase
  test "with color" do
    theme = Theme.new color: RainbowUnicorn::Color.new(235, 235, 235)
    assert_equal "#ebebeb", theme.color.hex
  end

  test "with hex string" do
    theme = Theme.new color: "ebebeb"
    assert_equal "#ebebeb", theme.color.hex
  end

  test "creating with numeric" do
    theme = Theme.create! color: RainbowUnicorn::Color.new(235, 235, 235)
    assert_equal "#ebebeb", theme.color.hex
  end
end
```